### PR TITLE
Remove exit() from cve.py and get.py

### DIFF
--- a/nvdlib/cve.py
+++ b/nvdlib/cve.py
@@ -52,7 +52,6 @@ def getCVE(CVEID, cpe_dict=False, key=False, verbose=False):
         except JSONDecodeError:
             print('Invalid CVE: ' + str(raw))
             print('Attempted search for CVE ID : ' + CVEID)
-            exit()
 
         # NIST 6 second rate limit recommendation on requests without API key - https://nvd.nist.gov/developers
         # Get a key, its easy.

--- a/nvdlib/get.py
+++ b/nvdlib/get.py
@@ -36,7 +36,6 @@ def __get(product, parameters, limit, key, verbose):
     except JSONDecodeError:
         print('Invalid search criteria syntax: ' + str(raw))
         print('Attempted search criteria: ' + str(parameters))
-        exit()
     
     time.sleep(delay) 
     totalResults = raw['totalResults']


### PR DESCRIPTION
`exit()` function is used in both `get.py (line 39)` and `cve.py (line 55)`. They cause the program to abort even when used in try-expect block, which is a major problem when searching for each element in a list. A module probably shouldn't decide when the program should exit.