### PR TITLE
Bugfix for TZ offset sign encoding

### DIFF
--- a/nvdlib/cpe.py
+++ b/nvdlib/cpe.py
@@ -93,7 +93,7 @@ def searchCPE(
                 date = datetime.strptime(lastModStartDate, '%Y-%m-%d %H:%M').isoformat()
             else:
                 raise SyntaxError('Invalid date syntax: ' + lastModStartDate)
-            parameters['lastModStartDate'] = date
+            parameters['lastModStartDate'] = date.replace('+', '%2B')
 
         if lastModEndDate:
             if isinstance(lastModEndDate, datetime):
@@ -102,7 +102,7 @@ def searchCPE(
                 date = datetime.strptime(lastModEndDate, '%Y-%m-%d %H:%M').isoformat()
             else:
                 raise SyntaxError('Invalid date syntax: ' + lastModEndDate)
-            parameters['lastModEndDate'] = date
+            parameters['lastModEndDate'] = date.replace('+', '%2B')
 
         if matchCriteriaId:
             parameters['matchCriteriaId'] = matchCriteriaId

--- a/nvdlib/cve.py
+++ b/nvdlib/cve.py
@@ -218,7 +218,7 @@ def searchCVE(
                 date = datetime.strptime(lastModStartDate, '%Y-%m-%d %H:%M').isoformat()
             else:
                 raise SyntaxError('Invalid date syntax: ' + lastModStartDate)
-            parameters['lastModStartDate'] = date
+            parameters['lastModStartDate'] = date.replace('+', '%2B')
 
         if lastModEndDate:
             if isinstance(lastModEndDate, datetime):
@@ -227,7 +227,7 @@ def searchCVE(
                 date = datetime.strptime(lastModEndDate, '%Y-%m-%d %H:%M').isoformat()
             else:
                 raise SyntaxError('Invalid date syntax: ' + lastModEndDate)
-            parameters['lastModEndDate'] = date
+            parameters['lastModEndDate'] = date.replace('+', '%2B')
         
         if noRejected:
             parameters['noRejected'] = None
@@ -239,7 +239,7 @@ def searchCVE(
                 date = datetime.strptime(pubStartDate, '%Y-%m-%d %H:%M').isoformat()
             else:
                 raise SyntaxError('Invalid date syntax: ' + pubEndDate)
-            parameters['pubStartDate'] = date
+            parameters['pubStartDate'] = date.replace('+', '%2B')
         
         if pubEndDate:
             if isinstance(pubEndDate, datetime):
@@ -248,7 +248,7 @@ def searchCVE(
                 date = datetime.strptime(pubEndDate, '%Y-%m-%d %H:%M').isoformat()
             else:
                 raise SyntaxError('Invalid date syntax: ' + pubEndDate)
-            parameters['pubEndDate'] = date
+            parameters['pubEndDate'] = date.replace('+', '%2B')
 
         if sourceIdentifier:
             parameters['sourceIdentifier'] = sourceIdentifier


### PR DESCRIPTION
NVD API documentation states the '+' used for a positive timezone offset in date/time should be encoded as '%2B'. A 404 error is returned if not. This fix replaces '+' found in the formatted datetime with '%2B'