### PR TITLE
Rate limit fix

### DIFF
--- a/nvdlib/get.py
+++ b/nvdlib/get.py
@@ -93,13 +93,14 @@ def __get_with_generator(product, headers, parameters, limit,
             [k if v is None else f"{k}={v}" for k, v in parameters.items()])
         if verbose:
             print('Filter:\n' + link + stringParams)
-
+        rate_delay = 1
         while True:
             raw = requests.get(link, params=stringParams,
                                headers=headers, timeout=30)
             if raw.status_code == 403:
-                print('Request returned a rate limit error. Retrying in 2 seconds...')
-                time.sleep(2)
+                print(f'Request returned a rate limit error. Retrying in {rate_delay} seconds...')
+                time.sleep(rate_delay)
+                rate_delay *= 2
             else:
                 break
 

--- a/nvdlib/get.py
+++ b/nvdlib/get.py
@@ -94,8 +94,15 @@ def __get_with_generator(product, headers, parameters, limit,
         if verbose:
             print('Filter:\n' + link + stringParams)
 
-        raw = requests.get(link, params=stringParams,
-                           headers=headers, timeout=30)
+        while True:
+            raw = requests.get(link, params=stringParams,
+                               headers=headers, timeout=30)
+            if raw.status_code == 403:
+                print('Request returned a rate limit error. Retrying in 2 seconds...')
+                time.sleep(2)
+            else:
+                break
+
         raw.encoding = 'utf-8'
         raw.raise_for_status()
 


### PR DESCRIPTION
If a 403 (rate limit error) is returned by the API, the generator becomes invalidated because it doesn't get the startIndex, totalResults, and resultsPerPage values from the response that it needs to continue the loop, thereby rendering the generator invalid. Modified the generator to check the response code then, if a rate limit is found, delay and retry until a valid response is received and the loop can continue.