### PR TITLE
Fix cwe attr in CVE

### DIFF
--- a/nvdlib/classes.py
+++ b/nvdlib/classes.py
@@ -213,7 +213,7 @@ class CVE:
             pass
         
         try:
-            self.cwe = [x.description[0] for x in self.weaknesses]
+            self.cwe = [x for w in self.weaknesses for x in w.description]
         except AttributeError:
             pass
 

--- a/tests/data/CVE-2017-7542.json
+++ b/tests/data/CVE-2017-7542.json
@@ -1,0 +1,163 @@
+{
+    "resultsPerPage": 1,
+    "startIndex": 0,
+    "totalResults": 1,
+    "format": "NVD_CVE",
+    "version": "2.0",
+    "timestamp": "2023-12-12T21:32:13.620",
+    "vulnerabilities": [
+        {
+            "cve": {
+                "id": "CVE-2017-7542",
+                "sourceIdentifier": "secalert@redhat.com",
+                "published": "2017-07-21T16:29:00.393",
+                "lastModified": "2023-02-12T23:30:40.070",
+                "vulnStatus": "Modified",
+                "descriptions": [
+                    {
+                        "lang": "en",
+                        "value": "The ip6_find_1stfragopt function in net/ipv6/output_core.c in the Linux kernel through 4.12.3 allows local users to cause a denial of service (integer overflow and infinite loop) by leveraging the ability to open a raw socket."
+                    },
+                    {
+                        "lang": "es",
+                        "value": "La función ip6_find_1stfragopt en el archivo net/ipv6/output_core.c en el kernel de Linux hasta la versión 4.12.3, permite a los usuarios locales causar una denegación de servicio (desbordamiento de enteros y bucle infinito) mediante la explotación de la capacidad de abrir un socket sin procesar."
+                    }
+                ],
+                "metrics": {
+                    "cvssMetricV30": [
+                        {
+                            "source": "nvd@nist.gov",
+                            "type": "Primary",
+                            "cvssData": {
+                                "version": "3.0",
+                                "vectorString": "CVSS:3.0/AV:L/AC:L/PR:L/UI:N/S:U/C:N/I:N/A:H",
+                                "attackVector": "LOCAL",
+                                "attackComplexity": "LOW",
+                                "privilegesRequired": "LOW",
+                                "userInteraction": "NONE",
+                                "scope": "UNCHANGED",
+                                "confidentialityImpact": "NONE",
+                                "integrityImpact": "NONE",
+                                "availabilityImpact": "HIGH",
+                                "baseScore": 5.5,
+                                "baseSeverity": "MEDIUM"
+                            },
+                            "exploitabilityScore": 1.8,
+                            "impactScore": 3.6
+                        }
+                    ],
+                    "cvssMetricV2": [
+                        {
+                            "source": "nvd@nist.gov",
+                            "type": "Primary",
+                            "cvssData": {
+                                "version": "2.0",
+                                "vectorString": "AV:L/AC:L/Au:N/C:N/I:N/A:C",
+                                "accessVector": "LOCAL",
+                                "accessComplexity": "LOW",
+                                "authentication": "NONE",
+                                "confidentialityImpact": "NONE",
+                                "integrityImpact": "NONE",
+                                "availabilityImpact": "COMPLETE",
+                                "baseScore": 4.9
+                            },
+                            "baseSeverity": "MEDIUM",
+                            "exploitabilityScore": 3.9,
+                            "impactScore": 6.9,
+                            "acInsufInfo": false,
+                            "obtainAllPrivilege": false,
+                            "obtainUserPrivilege": false,
+                            "obtainOtherPrivilege": false,
+                            "userInteractionRequired": false
+                        }
+                    ]
+                },
+                "weaknesses": [
+                    {
+                        "source": "secalert@redhat.com",
+                        "type": "Primary",
+                        "description": [{"lang": "en", "value": "CWE-190"}]
+                    },
+                    {
+                        "source": "nvd@nist.gov",
+                        "type": "Secondary",
+                        "description": [
+                            {"lang": "en", "value": "CWE-190"},
+                            {"lang": "en", "value": "CWE-835"}
+                        ]
+                    }
+                ],
+                "configurations": [
+                    {
+                        "nodes": [
+                            {
+                                "operator": "OR",
+                                "negate": false,
+                                "cpeMatch": [
+                                    {
+                                        "vulnerable": true,
+                                        "criteria": "cpe:2.3:o:linux:linux_kernel:*:*:*:*:*:*:*:*",
+                                        "versionEndIncluding": "4.12.3",
+                                        "matchCriteriaId": "93B616B9-0E9C-48F4-B663-8278767861FB"
+                                    }
+                                ]
+                            }
+                        ]
+                    }
+                ],
+                "references": [
+                    {
+                        "url": "http://git.kernel.org/cgit/linux/kernel/git/torvalds/linux.git/commit/?id=6399f1fae4ec29fab5ec76070435555e256ca3a6",
+                        "source": "secalert@redhat.com",
+                        "tags": ["Issue Tracking", "Patch", "Third Party Advisory"]
+                    },
+                    {
+                        "url": "http://www.debian.org/security/2017/dsa-3927",
+                        "source": "secalert@redhat.com"
+                    },
+                    {
+                        "url": "http://www.debian.org/security/2017/dsa-3945",
+                        "source": "secalert@redhat.com"
+                    },
+                    {
+                        "url": "http://www.securityfocus.com/bid/99953",
+                        "source": "secalert@redhat.com"
+                    },
+                    {
+                        "url": "https://access.redhat.com/errata/RHSA-2017:2918",
+                        "source": "secalert@redhat.com"
+                    },
+                    {
+                        "url": "https://access.redhat.com/errata/RHSA-2017:2930",
+                        "source": "secalert@redhat.com"
+                    },
+                    {
+                        "url": "https://access.redhat.com/errata/RHSA-2017:2931",
+                        "source": "secalert@redhat.com"
+                    },
+                    {
+                        "url": "https://access.redhat.com/errata/RHSA-2018:0169",
+                        "source": "secalert@redhat.com"
+                    },
+                    {
+                        "url": "https://github.com/torvalds/linux/commit/6399f1fae4ec29fab5ec76070435555e256ca3a6",
+                        "source": "secalert@redhat.com",
+                        "tags": ["Issue Tracking", "Patch", "Third Party Advisory"]
+                    },
+                    {
+                        "url": "https://help.ecostruxureit.com/display/public/UADCE725/Security+fixes+in+StruxureWare+Data+Center+Expert+v7.6.0",
+                        "source": "secalert@redhat.com"
+                    },
+                    {
+                        "url": "https://usn.ubuntu.com/3583-1/",
+                        "source": "secalert@redhat.com"
+                    },
+                    {
+                        "url": "https://usn.ubuntu.com/3583-2/",
+                        "source": "secalert@redhat.com"
+                    }
+                ]
+            }
+        }
+    ]
+}

--- a/tests/test_search.py
+++ b/tests/test_search.py
@@ -18,6 +18,10 @@ def mock_nvd():
             "tests/data/CVE-2022-24646.json",
         ),
         (
+            "https://services.nvd.nist.gov/rest/json/cves/2.0?cveId=CVE-2017-7542",
+            "tests/data/CVE-2017-7542.json",
+        ),
+        (
             "https://services.nvd.nist.gov/rest/json/cves/2.0?pubStartDate=2022-02-10T00:00:00&pubEndDate=2022-02-10T12:00:00",
             "tests/data/simple_search.json",
         ),
@@ -137,3 +141,15 @@ def test_search_cve_returns_a_cve_v2():
         verbose=True
     )]
     assert isinstance(results[1], nvdlib.classes.CVE)
+
+
+@responses.activate
+def test_cve_cwe():
+    """Test that `cwe` was correctly created from `weaknesses`."""
+    mock_nvd()
+    cve = nvdlib.searchCVE(cveId="CVE-2017-7542", verbose=True)[0]
+
+    assert cve.id == "CVE-2017-7542"
+    assert len(cve.cwe) == 3
+    assert len([x for w in cve.weaknesses for x in w.description]) == 3
+    assert cve.cwe == cve.weaknesses[0].description + cve.weaknesses[1].description


### PR DESCRIPTION
Hi! This PR fixes the creation of the `cwe` attribute in the `CVE` class. Originally, this attribute was created based on the first item in the `weaknesses`'s `description`, but `description` can be of bigger length, and some information could be lost.

To replicate this bug:
```
import nvdlib
cve = nvdlib.searchCVE(cveId="CVE-2017-7542")[0]
[x for w in cve.weaknesses for x in w.description]
>>> [{'lang': 'en', 'value': 'CWE-190'}, {'lang': 'en', 'value': 'CWE-190'}, {'lang': 'en', 'value': 'CWE-835'}]
cve.cwe
>>> [{'lang': 'en', 'value': 'CWE-190'}, {'lang': 'en', 'value': 'CWE-190'}]
```
The output of two last commands should be the same.