### PR TITLE
Add startIndex parameter for flexible data retrieval

### DIFF
--- a/nvdlib/cpe.py
+++ b/nvdlib/cpe.py
@@ -17,15 +17,16 @@ def searchCPE(
         lastModEndDate: Tuple[str, datetime] = None,
         matchCriteriaId: str = None,
         limit: int = None,
+        startIndex: int = 0,
         key: str = None,
         delay: int = None,
         verbose: bool = None) -> list:
     """Build and send GET request then return list of objects containing a collection of CPEs.
-    
+
     :param cpeNameId: Returns a specific CPE record using its UUID. If a correctly formatted UUID is passed but it does not exist, it will return empty results. The UUID is the `cpeNameId` value when searching CPE.
     :type cpeNameId: str
 
-    :param cpeMatchString: Use a partial CPE name to search for other CPE names. 
+    :param cpeMatchString: Use a partial CPE name to search for other CPE names.
     :type cpeMatchString: str
 
     :param keywordExactMatch: Searches metadata within CPE title and reference links for an exact match of the phrase or word passed to it. Must be included with `keywordSearch`.
@@ -51,17 +52,18 @@ def searchCPE(
     :param limit: Limits the number of results of the search.
     :type limit: int
 
+    :param startIndex: The index to start the search from. By default, the search starts at 0.
+    :type startIndex: int
+
     :param key: NVD API Key. Allows for a request every 0.6 seconds instead of 6 seconds.
     :type key: str
 
     :param delay: Can only be used if an API key is provided. The amount of time to sleep in between requests. Must be a value above 0.6 seconds if an API key is present. `delay` is set to 6 seconds if no API key is passed.
-    :type verbose: bool   
+    :type verbose: bool
 
     :param verbose: Prints the URL request for debugging purposes.
     :type verbose: bool
     """
-
-
 
     # Build the URL for the request
     parameters, headers = __buildCPECall(
@@ -73,11 +75,12 @@ def searchCPE(
         lastModEndDate,
         matchCriteriaId,
         limit,
+        startIndex,
         key,
         delay)
 
     # Send the GET request for the JSON and convert to dictionary
-    raw = __get('cpe', headers, parameters, limit, verbose, delay)
+    raw = __get('cpe', headers, parameters, limit, verbose, delay,)
     cpes = []
     # Generates the CVEs into objects for easy referencing and appends them to self.cves
     for eachCPE in raw['products']:
@@ -95,15 +98,16 @@ def searchCPE_V2(
         lastModEndDate: Tuple[str, datetime] = None,
         matchCriteriaId: str = None,
         limit: int = None,
+        startIndex: int = 0,
         key: str = None,
         delay: int = None,
         verbose: bool = None) -> Generator[list, None, list]:
     """Build and send GET request then return list of objects containing a collection of CPEs.
-    
+
     :param cpeNameId: Returns a specific CPE record using its UUID. If a correctly formatted UUID is passed but it does not exist, it will return empty results. The UUID is the `cpeNameId` value when searching CPE.
     :type cpeNameId: str
 
-    :param cpeMatchString: Use a partial CPE name to search for other CPE names. 
+    :param cpeMatchString: Use a partial CPE name to search for other CPE names.
     :type cpeMatchString: str
 
     :param keywordExactMatch: Searches metadata within CPE title and reference links for an exact match of the phrase or word passed to it. Must be included with `keywordSearch`.
@@ -126,15 +130,17 @@ def searchCPE_V2(
     :param matchCriteriaId: Returns CPE records associated with a match string by its UUID. Requires a properly formatted UUID.
     :type matchCriteriaId: str
 
-
     :param limit: Limits the number of results of the search.
     :type limit: int
+
+    :param startIndex: The index to start the search from. By default, the search starts at 0.
+    :type startIndex: int
 
     :param key: NVD API Key. Allows for a request every 0.6 seconds instead of 6 seconds.
     :type key: str
 
     :param delay: Can only be used if an API key is provided. The amount of time to sleep in between requests. Must be a value above 0.6 seconds if an API key is present. `delay` is set to 6 seconds if no API key is passed.
-    :type verbose: bool   
+    :type verbose: bool
 
     :param verbose: Prints the URL request for debugging purposes.
     :type verbose: bool
@@ -150,6 +156,7 @@ def searchCPE_V2(
         lastModEndDate,
         matchCriteriaId,
         limit,
+        startIndex,
         key,
         delay)
 
@@ -171,6 +178,7 @@ def __buildCPECall(
     lastModEndDate,
     matchCriteriaId,
     limit,
+    startIndex,
     key,
     delay):
 
@@ -188,10 +196,10 @@ def __buildCPECall(
             parameters['keywordExactMatch'] = None
         else:
             raise SyntaxError('keywordSearch parameter must be passed if keywordExactMatch is set to True.')
-    
+
     if keywordSearch:
         parameters['keywordSearch'] = keywordSearch
-    
+
     if lastModStartDate:
         if isinstance(lastModStartDate, datetime):
             date = lastModStartDate.isoformat()
@@ -229,6 +237,11 @@ def __buildCPECall(
     elif delay and not key:
         raise SyntaxError('Key parameter must be present to define a delay. Requests are delayed 6 seconds without an API key by default.')
 
+    if startIndex:
+        parameters['startIndex'] = startIndex
+    else:
+        parameters['startIndex'] = 0
+
     return parameters, headers
 
 def __buildCPEMatchCall(
@@ -238,6 +251,7 @@ def __buildCPEMatchCall(
     matchCriteriaId,
     matchStringSearch,
     limit,
+    startIndex,
     key,
     delay):
 
@@ -245,7 +259,7 @@ def __buildCPEMatchCall(
 
     if cveId:
         parameters['cveId'] = cveId
-    
+
     if lastModStartDate:
         if isinstance(lastModStartDate, datetime):
             date = lastModStartDate.isoformat()
@@ -286,6 +300,11 @@ def __buildCPEMatchCall(
     elif delay and not key:
         raise SyntaxError('Key parameter must be present to define a delay. Requests are delayed 6 seconds without an API key by default.')
 
+    if startIndex:
+        parameters['startIndex'] = startIndex
+    else:
+        parameters['startIndex'] = 0
+
     return parameters, headers
 
 def searchCPEmatch(
@@ -295,11 +314,12 @@ def searchCPEmatch(
         matchCriteriaId: str = None,
         matchStringSearch: str = None,
         limit: int = None,
+        startIndex: int = 0,
         key: str = None,
         delay: int = None,
         verbose: bool = None) -> list:
     """Build and send GET request then return list of objects containing a collection of CPEs.
-    
+
     :param cveId: Returns all matching CPE match strings for a CVE.
     :type cveId: str
 
@@ -323,17 +343,18 @@ def searchCPEmatch(
     :param limit: Limits the number of results of the search.
     :type limit: int
 
+    :param startIndex: The index to start the search from. By default, the search starts at 0.
+    :type startIndex: int
+
     :param key: NVD API Key. Allows for a request every 0.6 seconds instead of 6 seconds.
     :type key: str
 
     :param delay: Can only be used if an API key is provided. The amount of time to sleep in between requests. Must be a value above 0.6 seconds if an API key is present. `delay` is set to 6 seconds if no API key is passed.
-    :type verbose: bool   
+    :type verbose: bool
 
     :param verbose: Prints the URL request for debugging purposes.
     :type verbose: bool
     """
-
-
 
     # Build the URL for the request
     parameters, headers = __buildCPEMatchCall(
@@ -343,6 +364,7 @@ def searchCPEmatch(
         matchCriteriaId,
         matchStringSearch,
         limit,
+        startIndex,
         key,
         delay)
 

--- a/nvdlib/cve.py
+++ b/nvdlib/cve.py
@@ -34,6 +34,7 @@ def searchCVE(
         versionStartType: str = None,
         virtualMatchString: str = None,
         limit: int = None,
+        startIndex: int = None,
         delay: int = None,
         key: str = None,
         verbose: bool = None) -> list:
@@ -117,6 +118,9 @@ def searchCVE(
     :param limit: Custom argument to limit the number of results of the search. Allowed any number between 1 and 2000.
     :type limit: int
 
+    :param startIndex: The index to start the search from. By default, the search starts at 0.
+    :type startIndex: int
+
     :param delay: Can only be used if an API key is provided. This allows the user to define a delay. The delay must be greater than 0.6 seconds. The NVD API recommends scripts sleep for atleast 6 seconds in between requests.
     :type delay: int
 
@@ -154,6 +158,7 @@ def searchCVE(
         versionStartType,
         virtualMatchString,
         limit,
+        startIndex,
         delay,
         key)
 
@@ -193,6 +198,7 @@ def searchCVE_V2(
         versionStartType: str = None,
         virtualMatchString: str = None,
         limit: int = None,
+        startIndex: int = None,
         delay: int = None,
         key: str = None,
         verbose: bool = None) -> Generator[list, None, list]:
@@ -276,6 +282,9 @@ def searchCVE_V2(
     :param limit: Custom argument to limit the number of results of the search. Allowed any number between 1 and 2000.
     :type limit: int
 
+    :param startIndex: The index to start the search from. By default, the search starts at 0.
+    :type startIndex: int
+
     :param delay: Can only be used if an API key is provided. This allows the user to define a delay. The delay must be greater than 0.6 seconds. The NVD API recommends scripts sleep for atleast 6 seconds in between requests.
     :type delay: int
 
@@ -312,6 +321,7 @@ def searchCVE_V2(
         versionStartType,
         virtualMatchString,
         limit,
+        startIndex,
         delay,
         key)
 
@@ -350,6 +360,7 @@ def __buildCVECall(
         versionStartType,
         virtualMatchString,
         limit,
+        startIndex,
         delay,
         key):
 
@@ -512,5 +523,10 @@ def __buildCVECall(
     elif delay and not key:
         raise SyntaxError(
             'Key parameter must be present to define a delay. Requests are delayed 6 seconds without an API key by default.')
+
+    if startIndex:
+        parameters['startIndex'] = startIndex
+    else:
+        parameters['startIndex'] = 0
 
     return parameters, headers

--- a/nvdlib/get.py
+++ b/nvdlib/get.py
@@ -48,7 +48,7 @@ def __get(product, headers, parameters, limit, verbose, delay):
     # Add each ['vulnerabilities'] or ['products'] list from each page to the end of the first request. Effectively creates one data point.
     elif totalResults > 2000:
         pages = (totalResults // 2000)
-        startIndex = 2000
+        startIndex = parameters['startIndex'] + 2000
         if product == 'cve':
             path = 'vulnerabilities'
         else:
@@ -82,7 +82,7 @@ def __get(product, headers, parameters, limit, verbose, delay):
 
 
 def __get_with_generator(product, headers, parameters, limit,
-                         verbose, delay):
+                       verbose, delay):
     # Get the default 2000 items to see the totalResults and determine pages required.
     if product == 'cve':
         link = 'https://services.nvd.nist.gov/rest/json/cves/2.0?'
@@ -90,7 +90,9 @@ def __get_with_generator(product, headers, parameters, limit,
         link = 'https://services.nvd.nist.gov/rest/json/cpes/2.0?'
     elif product == 'cpeMatch':
         link = 'https://services.nvd.nist.gov/rest/json/cpes/2.0?'
-    startIndex = 0
+
+    startIndex = parameters['startIndex']
+
     while True:
         stringParams = '&'.join(
             [k if v is None else f"{k}={v}" for k, v in parameters.items()])

--- a/tests/test_search.py
+++ b/tests/test_search.py
@@ -6,31 +6,31 @@ import json
 def mock_nvd():
     for url, response_file in [
         (
-            "https://services.nvd.nist.gov/rest/json/cves/2.0?cveId=CVE-2021-45357",
+            "https://services.nvd.nist.gov/rest/json/cves/2.0?cveId=CVE-2021-45357&startIndex=0",
             "tests/data/CVE-2021-45357.json",
         ),
         (
-            "https://services.nvd.nist.gov/rest/json/cves/2.0?cveId=CVE-2021-26855",
+            "https://services.nvd.nist.gov/rest/json/cves/2.0?cveId=CVE-2021-26855&startIndex=0",
             "tests/data/CVE-2021-26855.json",
         ),
         (
-            "https://services.nvd.nist.gov/rest/json/cves/2.0?cveId=CVE-2021-45357",
+            "https://services.nvd.nist.gov/rest/json/cves/2.0?cveId=CVE-2021-45357&startIndex=0",
             "tests/data/CVE-2022-24646.json",
         ),
         (
-            "https://services.nvd.nist.gov/rest/json/cves/2.0?cveId=CVE-2017-7542",
+            "https://services.nvd.nist.gov/rest/json/cves/2.0?cveId=CVE-2017-7542&startIndex=0",
             "tests/data/CVE-2017-7542.json",
         ),
         (
-            "https://services.nvd.nist.gov/rest/json/cves/2.0?pubStartDate=2022-02-10T00:00:00&pubEndDate=2022-02-10T12:00:00",
+            "https://services.nvd.nist.gov/rest/json/cves/2.0?pubStartDate=2022-02-10T00:00:00&pubEndDate=2022-02-10T12:00:00&startIndex=0",
             "tests/data/simple_search.json",
         ),
         (
-            "https://services.nvd.nist.gov/rest/json/cves/2.0?pubStartDate=2022-02-10T00:00:00&pubEndDate=2022-02-11T00:00:00",
+            "https://services.nvd.nist.gov/rest/json/cves/2.0?pubStartDate=2022-02-10T00:00:00&pubEndDate=2022-02-11T00:00:00&startIndex=0",
             "tests/data/search_page_1.json",
         ),
         (
-            "https://services.nvd.nist.gov/rest/json/cves/2.0?pubStartDate=2022-02-10T00:00:00&pubEndDate=2022-02-11T00:00:00",
+            "https://services.nvd.nist.gov/rest/json/cves/2.0?pubStartDate=2022-02-10T00:00:00&pubEndDate=2022-02-11T00:00:00&startIndex=0",
             "tests/data/search_full_page.json",
         ),
     ]:


### PR DESCRIPTION
This PR introduces a new `startIndex` parameter to the search functions, enhancing the flexibility of data retrieval in nvdlib. 

This feature allows for recovery from collection failures (e.g., due to unstable NVD API) without having to restart the entire process from the beginning. Users can now continue collecting CVEs from where they left off.