### PR TITLE
Add suspected missing if/else case to classes.py

### DIFF
--- a/nvdlib/classes.py
+++ b/nvdlib/classes.py
@@ -309,12 +309,15 @@ class CVE:
         else:
             self.score = [None, None, None]
 
-def __convert(product: Literal["cve", "cpe", "MatchString"], CVEID: Any) -> Union[CVE, CPE]:
+def __convert(product: Literal["cve", "cpe", "MatchString"], CVEID: Any) -> Union[CVE, CPE, MatchString]:
     """Convert the JSON response to a referenceable object."""
     if product == 'cve':
         vuln = json.loads(json.dumps(CVEID), object_hook= CVE)
         vuln.getvars()
         return vuln
-    else:
+    elif product == 'cpe':
         cpeEntry = json.loads(json.dumps(CVEID), object_hook= CPE)
         return cpeEntry 
+    else:
+        matchString = json.loads(json.dumps(CVEID), object_hook= MatchString)
+        return matchString

--- a/nvdlib/classes.py
+++ b/nvdlib/classes.py
@@ -1,5 +1,5 @@
 import json
-from typing import Any
+from typing import Any, Union, Literal
 
 
 class CPE:
@@ -309,7 +309,7 @@ class CVE:
         else:
             self.score = [None, None, None]
 
-def __convert(product: str, CVEID: Any):
+def __convert(product: Literal["cve", "cpe", "MatchString"], CVEID: Any) -> Union[CVE, CPE]:
     """Convert the JSON response to a referenceable object."""
     if product == 'cve':
         vuln = json.loads(json.dumps(CVEID), object_hook= CVE)

--- a/nvdlib/classes.py
+++ b/nvdlib/classes.py
@@ -1,4 +1,6 @@
 import json
+from typing import Any
+
 
 class CPE:
     """JSON dump class for CPEs
@@ -307,7 +309,7 @@ class CVE:
         else:
             self.score = [None, None, None]
 
-def __convert(product, CVEID):
+def __convert(product: str, CVEID: Any):
     """Convert the JSON response to a referenceable object."""
     if product == 'cve':
         vuln = json.loads(json.dumps(CVEID), object_hook= CVE)

--- a/nvdlib/cpe.py
+++ b/nvdlib/cpe.py
@@ -1,10 +1,10 @@
 import datetime
 import urllib.parse
 
-from typing import Generator, Union, Optional
+from typing import Generator, Union, Optional, List, Any, Tuple, LiteralString, Dict
 from datetime import datetime
 from .get import __get, __get_with_generator
-from .classes import __convert
+from .classes import __convert, CPE
 
 
 def searchCPE(
@@ -18,7 +18,7 @@ def searchCPE(
         limit: Optional[int] = None,
         key: Optional[str] = None,
         delay: Optional[float] = None
-) -> list:
+) -> List[CPE]:
     """Build and send GET request then return list of objects containing a collection of CPEs.
     
     :param cpeNameId: Returns a specific CPE record using its UUID. If a correctly formatted UUID is passed but it does not exist, it will return empty results. The UUID is the `cpeNameId` value when searching CPE.
@@ -93,7 +93,7 @@ def searchCPE_V2(
         limit: Optional[int] = None,
         key: Optional[str] = None,
         delay: Optional[float] = None
-) -> Generator[list, None, list]:
+) -> Generator[CPE, Any, None]:
     """Build and send GET request then return list of objects containing a collection of CPEs.
     
     :param cpeNameId: Returns a specific CPE record using its UUID. If a correctly formatted UUID is passed but it does not exist, it will return empty results. The UUID is the `cpeNameId` value when searching CPE.
@@ -165,7 +165,7 @@ def __buildCPECall(
         limit: Optional[int] = None,
         key: Optional[str] = None,
         delay: Optional[float] = None
-):
+) -> Tuple[Dict[str, Union[str, bool, LiteralString, int]], Dict[str, str]]:
 
     parameters = {}
 
@@ -233,7 +233,7 @@ def __buildCPEMatchCall(
     limit: Optional[int] = None,
     key: Optional[str] = None,
     delay: Optional[float] = None
-):
+) -> Tuple[Dict[str, Union[str, bool, LiteralString, int]], Dict[str, str]]:
 
     parameters = {}
 
@@ -291,7 +291,7 @@ def searchCPEmatch(
         limit: Optional[int] = None,
         key: Optional[str] = None,
         delay: Optional[float] = None
-) -> list:
+) -> List[CPE]:
     """Build and send GET request then return list of objects containing a collection of CPEs.
     
     :param cveId: Returns all matching CPE match strings for a CVE.

--- a/nvdlib/cpe.py
+++ b/nvdlib/cpe.py
@@ -1,24 +1,24 @@
 import datetime
 import urllib.parse
 
-from typing import Generator
-from typing import Tuple
+from typing import Generator, Union, Optional
 from datetime import datetime
 from .get import __get, __get_with_generator
 from .classes import __convert
 
 
 def searchCPE(
-        cpeNameId: str = None,
-        cpeMatchString: str = None,
-        keywordExactMatch: bool = None,
-        keywordSearch: str = None,
-        lastModStartDate: Tuple[str, datetime] = None,
-        lastModEndDate: Tuple[str, datetime] = None,
-        matchCriteriaId: str = None,
-        limit: int = None,
-        key: str = None,
-        delay: float = None) -> list:
+        cpeNameId: Optional[str] = None,
+        cpeMatchString: Optional[str] = None,
+        keywordExactMatch: Optional[bool] = None,
+        keywordSearch: Optional[str] = None,
+        lastModStartDate: Optional[Union[str, datetime]] = None,
+        lastModEndDate: Optional[Union[str, datetime]] = None,
+        matchCriteriaId: Optional[str] = None,
+        limit: Optional[int] = None,
+        key: Optional[str] = None,
+        delay: Optional[float] = None
+) -> list:
     """Build and send GET request then return list of objects containing a collection of CPEs.
     
     :param cpeNameId: Returns a specific CPE record using its UUID. If a correctly formatted UUID is passed but it does not exist, it will return empty results. The UUID is the `cpeNameId` value when searching CPE.
@@ -83,16 +83,17 @@ def searchCPE(
 
 
 def searchCPE_V2(
-        cpeNameId: str = None,
-        cpeMatchString: str = None,
-        keywordExactMatch: bool = None,
-        keywordSearch: str = None,
-        lastModStartDate: Tuple[str, datetime] = None,
-        lastModEndDate: Tuple[str, datetime] = None,
-        matchCriteriaId: str = None,
-        limit: int = None,
-        key: str = None,
-        delay: float = None) -> Generator[list, None, list]:
+        cpeNameId: Optional[str] = None,
+        cpeMatchString: Optional[str] = None,
+        keywordExactMatch: Optional[bool] = None,
+        keywordSearch: Optional[str] = None,
+        lastModStartDate: Optional[Union[str, datetime]] = None,
+        lastModEndDate: Optional[Union[str, datetime]] = None,
+        matchCriteriaId: Optional[str] = None,
+        limit: Optional[int] = None,
+        key: Optional[str] = None,
+        delay: Optional[float] = None
+) -> Generator[list, None, list]:
     """Build and send GET request then return list of objects containing a collection of CPEs.
     
     :param cpeNameId: Returns a specific CPE record using its UUID. If a correctly formatted UUID is passed but it does not exist, it will return empty results. The UUID is the `cpeNameId` value when searching CPE.
@@ -154,36 +155,37 @@ def searchCPE_V2(
 
 
 def __buildCPECall(
-    cpeNameId,
-    cpeMatchString,
-    keywordExactMatch,
-    keywordSearch,
-    lastModStartDate,
-    lastModEndDate,
-    matchCriteriaId,
-    limit,
-    key,
-    delay):
+        cpeNameId: Optional[str] = None,
+        cpeMatchString: Optional[str] = None,
+        keywordExactMatch: Optional[bool] = None,
+        keywordSearch: Optional[str] = None,
+        lastModStartDate: Optional[Union[str, datetime]] = None,
+        lastModEndDate: Optional[Union[str, datetime]] = None,
+        matchCriteriaId: Optional[str] = None,
+        limit: Optional[int] = None,
+        key: Optional[str] = None,
+        delay: Optional[float] = None
+):
 
     parameters = {}
 
-    if cpeNameId:
+    if cpeNameId is not None:
         parameters['cpeNameId'] = cpeNameId
 
-    if cpeMatchString:
+    if cpeMatchString is not None:
         cpeMatchString = urllib.parse.quote_plus(cpeMatchString, encoding='utf-8')
         parameters['cpeMatchString'] = cpeMatchString
 
     if keywordExactMatch:
-        if keywordSearch:
-            parameters['keywordExactMatch'] = None
+        if keywordSearch is not None:
+            parameters['keywordExactMatch'] = keywordExactMatch
         else:
             raise SyntaxError('keywordSearch parameter must be passed if keywordExactMatch is set to True.')
     
-    if keywordSearch:
+    if keywordSearch is not None:
         parameters['keywordSearch'] = keywordSearch
     
-    if lastModStartDate:
+    if lastModStartDate is not None:
         if isinstance(lastModStartDate, datetime):
             date = lastModStartDate.isoformat()
         elif isinstance(lastModStartDate, str):
@@ -192,7 +194,7 @@ def __buildCPECall(
             raise SyntaxError('Invalid date syntax: ' + lastModStartDate)
         parameters['lastModStartDate'] = date.replace('+', '%2B')
 
-    if lastModEndDate:
+    if lastModEndDate is not None:
         if isinstance(lastModEndDate, datetime):
             date = lastModEndDate.isoformat()
         elif isinstance(lastModEndDate, str):
@@ -201,43 +203,44 @@ def __buildCPECall(
             raise SyntaxError('Invalid date syntax: ' + lastModEndDate)
         parameters['lastModEndDate'] = date.replace('+', '%2B')
 
-    if matchCriteriaId:
+    if matchCriteriaId is not None:
         parameters['matchCriteriaId'] = matchCriteriaId
 
-    if limit:
+    if limit is not None:
         if limit > 2000 or limit < 1:
             raise SyntaxError('Limit parameter must be between 1 and 2000')
         parameters['resultsPerPage'] = limit
 
-    if key:
+    if key is not None:
         headers = {'content-type': 'application/json', 'apiKey': key}
     else:
         headers = {'content-type': 'application/json'}
 
-    if delay and key:
+    if delay is not None and key is not None:
         if delay < 0.6:
             raise SyntaxError('Delay parameter must be greater than 0.6 seconds with an API key. NVD API recommends several seconds.')
-    elif delay and not key:
+    elif delay is not None and key is None:
         raise SyntaxError('Key parameter must be present to define a delay. Requests are delayed 6 seconds without an API key by default.')
 
     return parameters, headers
 
 def __buildCPEMatchCall(
-    cveId,
-    lastModStartDate,
-    lastModEndDate,
-    matchCriteriaId,
-    matchStringSearch,
-    limit,
-    key,
-    delay):
+    cveId: Optional[str] = None,
+    lastModStartDate: Union[str, datetime] = None,
+    lastModEndDate: Union[str, datetime] = None,
+    matchCriteriaId: Optional[str] = None,
+    matchStringSearch: Optional[str] = None,
+    limit: Optional[int] = None,
+    key: Optional[str] = None,
+    delay: Optional[float] = None
+):
 
     parameters = {}
 
-    if cveId:
+    if cveId is not None:
         parameters['cveId'] = cveId
     
-    if lastModStartDate:
+    if lastModStartDate is not None:
         if isinstance(lastModStartDate, datetime):
             date = lastModStartDate.isoformat()
         elif isinstance(lastModStartDate, str):
@@ -246,7 +249,7 @@ def __buildCPEMatchCall(
             raise SyntaxError('Invalid date syntax: ' + lastModStartDate)
         parameters['lastModStartDate'] = date.replace('+', '%2B')
 
-    if lastModEndDate:
+    if lastModEndDate is not None:
         if isinstance(lastModEndDate, datetime):
             date = lastModEndDate.isoformat()
         elif isinstance(lastModEndDate, str):
@@ -255,39 +258,40 @@ def __buildCPEMatchCall(
             raise SyntaxError('Invalid date syntax: ' + lastModEndDate)
         parameters['lastModEndDate'] = date.replace('+', '%2B')
 
-    if matchCriteriaId:
+    if matchCriteriaId is not None:
         parameters['matchCriteriaId'] = matchCriteriaId
 
-    if matchStringSearch:
+    if matchStringSearch is not None:
         parameters['matchStringSearch'] = matchStringSearch
 
-    if limit:
+    if limit is not None:
         if limit > 2000 or limit < 1:
             raise SyntaxError('Limit parameter must be between 1 and 2000')
         parameters['resultsPerPage'] = limit
 
-    if key:
+    if key is not None:
         headers = {'content-type': 'application/json', 'apiKey': key}
     else:
         headers = {'content-type': 'application/json'}
 
-    if delay and key:
+    if delay is not None and key is not None:
         if delay < 0.6:
             raise SyntaxError('Delay parameter must be greater than 0.6 seconds with an API key. NVD API recommends several seconds.')
-    elif delay and not key:
+    elif delay is not None and key is None:
         raise SyntaxError('Key parameter must be present to define a delay. Requests are delayed 6 seconds without an API key by default.')
 
     return parameters, headers
 
 def searchCPEmatch(
-        cveId: str = None,
-        lastModStartDate: Tuple[str, datetime] = None,
-        lastModEndDate: Tuple[str, datetime] = None,
-        matchCriteriaId: str = None,
-        matchStringSearch: str = None,
-        limit: int = None,
-        key: str = None,
-        delay: float = None) -> list:
+        cveId: Optional[str] = None,
+        lastModStartDate: Optional[Union[str, datetime]] = None,
+        lastModEndDate: Optional[Union[str, datetime]] = None,
+        matchCriteriaId: Optional[str] = None,
+        matchStringSearch: Optional[str] = None,
+        limit: Optional[int] = None,
+        key: Optional[str] = None,
+        delay: Optional[float] = None
+) -> list:
     """Build and send GET request then return list of objects containing a collection of CPEs.
     
     :param cveId: Returns all matching CPE match strings for a CVE.

--- a/nvdlib/cve.py
+++ b/nvdlib/cve.py
@@ -389,16 +389,16 @@ def __buildCVECall(
         parameters['cweId'] = cweId.upper()
 
     if hasCertAlerts is not None:
-        parameters['hasCertAlerts'] = None
+        parameters['hasCertAlerts'] = hasCertAlerts
 
     if hasCertNotes is not None:
-        parameters['hasCertNotes'] = None
+        parameters['hasCertNotes'] = hasCertNotes
 
     if hasKev is not None:
-        parameters['hasKev'] = None
+        parameters['hasKev'] = hasKev
 
     if hasOval is not None:
-        parameters['hasOval'] = None
+        parameters['hasOval'] = hasOval
 
     if isVulnerable is not None:
         if cpeName is not None:

--- a/nvdlib/cve.py
+++ b/nvdlib/cve.py
@@ -1,8 +1,8 @@
 import urllib.parse
 
-from typing import Generator, Optional, Union
+from typing import Generator, Optional, Union, List, Tuple, Any, Dict
 from datetime import datetime
-from .classes import __convert
+from .classes import __convert, CVE
 from .get import __get, __get_with_generator
 
 
@@ -36,7 +36,7 @@ def searchCVE(
         delay: Optional[float] = None,
         key: Optional[str] = None,
         verbose: Optional[bool] = None
-) -> list:
+) -> List[CVE]:
     """Build and send GET request then return list of objects containing a collection of CVEs. For more information on the parameters available, please visit https://nvd.nist.gov/developers/vulnerabilities 
 
     :param cpeName: This value will be compared agains the CPE Match Criteria within a CVE applicability statement. (i.e. find the vulnerabilities attached to that CPE). Partial match strings are allowed.
@@ -193,7 +193,7 @@ def searchCVE_V2(
         delay: Optional[float] = None,
         key: Optional[str] = None,
         verbose: Optional[bool] = None
-) -> Generator[list, None, list]:
+) -> Generator[List[CVE], Tuple[str, Any], None]:
     """Build and send GET request then return list of objects containing a collection of CVEs. For more information on the parameters available, please visit https://nvd.nist.gov/developers/vulnerabilities 
 
     :param cpeName: This value will be compared agains the CPE Match Criteria within a CVE applicability statement. (i.e. find the vulnerabilities attached to that CPE). Partial match strings are allowed.
@@ -348,7 +348,7 @@ def __buildCVECall(
         delay: Optional[float] = None,
         key: Optional[str] = None,
         verbose: Optional[bool] = None
-):
+) -> Tuple[Dict[str, Union[str, bool, None]], Dict[str, str]]:
 
     parameters = {}
 

--- a/nvdlib/cve.py
+++ b/nvdlib/cve.py
@@ -1,42 +1,42 @@
 import urllib.parse
 
-from typing import Generator
-from typing import Tuple
+from typing import Generator, Optional, Union
 from datetime import datetime
 from .classes import __convert
 from .get import __get, __get_with_generator
 
 
 def searchCVE(
-        cpeName: str = None,
-        cveId: str = None,
-        cvssV2Metrics: str = None,
-        cvssV2Severity: str = None,
-        cvssV3Metrics: str = None,
-        cvssV3Severity: str = None,
-        cweId: str = None,
-        hasCertAlerts: bool = None,
-        hasCertNotes: bool = None,
-        hasKev: bool = None,
-        hasOval: bool = None,
-        isVulnerable: bool = None,
-        keywordExactMatch: bool = None,
-        keywordSearch: str = None,
-        lastModStartDate: Tuple[str, datetime] = None,
-        lastModEndDate: Tuple[str, datetime] = None,
-        noRejected: bool = None,
-        pubStartDate: Tuple[str, datetime] = None,
-        pubEndDate: Tuple[str, datetime] = None,
-        sourceIdentifier: str = None,
-        versionEnd: str = None,
-        versionEndType: str = None,
-        versionStart: str = None,
-        versionStartType: str = None,
-        virtualMatchString: str = None,
-        limit: int = None,
-        delay: float = None,
-        key: str = None,
-        verbose: bool = None) -> list:
+        cpeName: Optional[str] = None,
+        cveId: Optional[str] = None,
+        cvssV2Metrics: Optional[str] = None,
+        cvssV2Severity: Optional[str] = None,
+        cvssV3Metrics: Optional[str] = None,
+        cvssV3Severity: Optional[str] = None,
+        cweId: Optional[str] = None,
+        hasCertAlerts: Optional[bool] = None,
+        hasCertNotes: Optional[bool] = None,
+        hasKev: Optional[bool] = None,
+        hasOval: Optional[bool] = None,
+        isVulnerable: Optional[bool] = None,
+        keywordExactMatch: Optional[bool] = None,
+        keywordSearch: Optional[str] = None,
+        lastModStartDate: Optional[Union[str, datetime]] = None,
+        lastModEndDate: Optional[Union[str, datetime]] = None,
+        noRejected: Optional[bool] = None,
+        pubStartDate: Optional[Union[str, datetime]] = None,
+        pubEndDate: Optional[Union[str, datetime]] = None,
+        sourceIdentifier: Optional[str] = None,
+        versionEnd: Optional[str] = None,
+        versionEndType: Optional[str] = None,
+        versionStart: Optional[str] = None,
+        versionStartType: Optional[str] = None,
+        virtualMatchString: Optional[str] = None,
+        limit: Optional[int] = None,
+        delay: Optional[float] = None,
+        key: Optional[str] = None,
+        verbose: Optional[bool] = None
+) -> list:
     """Build and send GET request then return list of objects containing a collection of CVEs. For more information on the parameters available, please visit https://nvd.nist.gov/developers/vulnerabilities 
 
     :param cpeName: This value will be compared agains the CPE Match Criteria within a CVE applicability statement. (i.e. find the vulnerabilities attached to that CPE). Partial match strings are allowed.
@@ -164,35 +164,36 @@ def searchCVE(
 
 
 def searchCVE_V2(
-        cpeName: str = None,
-        cveId: str = None,
-        cvssV2Metrics: str = None,
-        cvssV2Severity: str = None,
-        cvssV3Metrics: str = None,
-        cvssV3Severity: str = None,
-        cweId: str = None,
-        hasCertAlerts: bool = None,
-        hasCertNotes: bool = None,
-        hasKev: bool = None,
-        hasOval: bool = None,
-        isVulnerable: bool = None,
-        keywordExactMatch: bool = None,
-        keywordSearch: str = None,
-        lastModStartDate: Tuple[str, datetime] = None,
-        lastModEndDate: Tuple[str, datetime] = None,
-        noRejected: bool = None,
-        pubStartDate: Tuple[str, datetime] = None,
-        pubEndDate: Tuple[str, datetime] = None,
-        sourceIdentifier: str = None,
-        versionEnd: str = None,
-        versionEndType: str = None,
-        versionStart: str = None,
-        versionStartType: str = None,
-        virtualMatchString: str = None,
-        limit: int = None,
-        delay: float = None,
-        key: str = None,
-        verbose: bool = None) -> Generator[list, None, list]:
+        cpeName: Optional[str] = None,
+        cveId: Optional[str] = None,
+        cvssV2Metrics: Optional[str] = None,
+        cvssV2Severity: Optional[str] = None,
+        cvssV3Metrics: Optional[str] = None,
+        cvssV3Severity: Optional[str] = None,
+        cweId: Optional[str] = None,
+        hasCertAlerts: Optional[bool] = None,
+        hasCertNotes: Optional[bool] = None,
+        hasKev: Optional[bool] = None,
+        hasOval: Optional[bool] = None,
+        isVulnerable: Optional[bool] = None,
+        keywordExactMatch: Optional[bool] = None,
+        keywordSearch: Optional[str] = None,
+        lastModStartDate: Optional[Union[str, datetime]] = None,
+        lastModEndDate: Optional[Union[str, datetime]] = None,
+        noRejected: Optional[bool] = None,
+        pubStartDate: Optional[Union[str, datetime]] = None,
+        pubEndDate: Optional[Union[str, datetime]] = None,
+        sourceIdentifier: Optional[str] = None,
+        versionEnd: Optional[str] = None,
+        versionEndType: Optional[str] = None,
+        versionStart: Optional[str] = None,
+        versionStartType: Optional[str] = None,
+        virtualMatchString: Optional[str] = None,
+        limit: Optional[int] = None,
+        delay: Optional[float] = None,
+        key: Optional[str] = None,
+        verbose: Optional[bool] = None
+) -> Generator[list, None, list]:
     """Build and send GET request then return list of objects containing a collection of CVEs. For more information on the parameters available, please visit https://nvd.nist.gov/developers/vulnerabilities 
 
     :param cpeName: This value will be compared agains the CPE Match Criteria within a CVE applicability statement. (i.e. find the vulnerabilities attached to that CPE). Partial match strings are allowed.
@@ -318,50 +319,52 @@ def searchCVE_V2(
 
 
 def __buildCVECall(
-        cpeName,
-        cveId,
-        cvssV2Metrics,
-        cvssV2Severity,
-        cvssV3Metrics,
-        cvssV3Severity,
-        cweId,
-        hasCertAlerts,
-        hasCertNotes,
-        hasKev,
-        hasOval,
-        isVulnerable,
-        keywordExactMatch,
-        keywordSearch,
-        lastModStartDate,
-        lastModEndDate,
-        noRejected,
-        pubStartDate,
-        pubEndDate,
-        sourceIdentifier,
-        versionEnd,
-        versionEndType,
-        versionStart,
-        versionStartType,
-        virtualMatchString,
-        limit,
-        delay,
-        key):
+        cpeName: Optional[str] = None,
+        cveId: Optional[str] = None,
+        cvssV2Metrics: Optional[str] = None,
+        cvssV2Severity: Optional[str] = None,
+        cvssV3Metrics: Optional[str] = None,
+        cvssV3Severity: Optional[str] = None,
+        cweId: Optional[str] = None,
+        hasCertAlerts: Optional[bool] = None,
+        hasCertNotes: Optional[bool] = None,
+        hasKev: Optional[bool] = None,
+        hasOval: Optional[bool] = None,
+        isVulnerable: Optional[bool] = None,
+        keywordExactMatch: Optional[bool] = None,
+        keywordSearch: Optional[str] = None,
+        lastModStartDate: Optional[Union[str, datetime]] = None,
+        lastModEndDate: Optional[Union[str, datetime]] = None,
+        noRejected: Optional[bool] = None,
+        pubStartDate: Optional[Union[str, datetime]] = None,
+        pubEndDate: Optional[Union[str, datetime]] = None,
+        sourceIdentifier: Optional[str] = None,
+        versionEnd: Optional[str] = None,
+        versionEndType: Optional[str] = None,
+        versionStart: Optional[str] = None,
+        versionStartType: Optional[str] = None,
+        virtualMatchString: Optional[str] = None,
+        limit: Optional[int] = None,
+        delay: Optional[float] = None,
+        key: Optional[str] = None,
+        verbose: Optional[bool] = None
+):
 
     parameters = {}
 
-    if cpeName:
+    if cpeName is not None:
         cpeName = urllib.parse.quote_plus(cpeName, encoding='utf-8')
         parameters['cpeName'] = cpeName
 
-    if cveId:
+    if cveId is not None:
         parameters['cveId'] = cveId
 
-    if cvssV2Metrics:
+    if cvssV2Metrics is not None:
         cvssV2Metrics = urllib.parse.quote_plus(
             cvssV2Metrics, encoding='utf-8')
         parameters['cvssV2Metrics'] = cvssV2Metrics
 
-    if cvssV2Severity:
+    if cvssV2Severity is not None:
         cvssV2Severity = cvssV2Severity.upper()
         if cvssV2Severity in ['LOW', 'MEDIUM', 'HIGH']:
             parameters['cvssV2Severity'] = cvssV2Severity
@@ -369,12 +372,12 @@ def __buildCVECall(
             raise SyntaxError(
                 "cvssV2Severity parameter can only be assigned LOW, MEDIUM, or HIGH value.")
 
-    if cvssV3Metrics:
+    if cvssV3Metrics is not None:
         cvssV3Metrics = urllib.parse.quote_plus(
             cvssV3Metrics, encoding='utf-8')
         parameters['cvssV3Metrics'] = cvssV3Metrics
 
-    if cvssV3Severity:
+    if cvssV3Severity is not None:
         cvssV3Severity = cvssV3Severity.upper()
         if cvssV3Severity in ['LOW', 'MEDIUM', 'HIGH', 'CRITICAL']:
             parameters['cvssV3Severity'] = cvssV3Severity
@@ -382,39 +385,39 @@ def __buildCVECall(
             raise SyntaxError(
                 "cvssV3Severity parameter can only be assigned LOW, MEDIUM, HIGH, or CRITICAL value.")
 
-    if cweId:
+    if cweId is not None:
         parameters['cweId'] = cweId.upper()
 
-    if hasCertAlerts:
+    if hasCertAlerts is not None:
         parameters['hasCertAlerts'] = None
 
-    if hasCertNotes:
+    if hasCertNotes is not None:
         parameters['hasCertNotes'] = None
 
-    if hasKev:
+    if hasKev is not None:
         parameters['hasKev'] = None
 
-    if hasOval:
+    if hasOval is not None:
         parameters['hasOval'] = None
 
-    if isVulnerable:
-        if cpeName:
-            parameters['isVulnerable'] = None
+    if isVulnerable is not None:
+        if cpeName is not None:
+            parameters['isVulnerable'] = isVulnerable
         else:
             raise SyntaxError(
                 'cpeName parameter must be defined if isVulnerable parameter is passed.')
 
-    if keywordExactMatch:
+    if keywordExactMatch is not None:
         if keywordSearch:
-            parameters['keywordExactMatch'] = None
+            parameters['keywordExactMatch'] = keywordExactMatch
         else:
             raise SyntaxError(
                 'keywordSearch parameter must be passed if keywordExactMatch is set to True.')
 
-    if keywordSearch:
+    if keywordSearch is not None:
         parameters['keywordSearch'] = keywordSearch
 
-    if lastModStartDate:
+    if lastModStartDate is not None:
         if isinstance(lastModStartDate, datetime):
             date = lastModStartDate.isoformat()
         elif isinstance(lastModStartDate, str):
@@ -424,7 +427,7 @@ def __buildCVECall(
             raise SyntaxError('Invalid date syntax: ' + lastModStartDate)
         parameters['lastModStartDate'] = date.replace('+', '%2B')
 
-    if lastModEndDate:
+    if lastModEndDate is not None:
         if isinstance(lastModEndDate, datetime):
             date = lastModEndDate.isoformat()
         elif isinstance(lastModEndDate, str):
@@ -434,10 +437,10 @@ def __buildCVECall(
             raise SyntaxError('Invalid date syntax: ' + lastModEndDate)
         parameters['lastModEndDate'] = date.replace('+', '%2B')
 
-    if noRejected:
+    if noRejected is not None:
         parameters['noRejected'] = None
 
-    if pubStartDate:
+    if pubStartDate is not None:
         if isinstance(pubStartDate, datetime):
             date = pubStartDate.isoformat()
         elif isinstance(pubStartDate, str):
@@ -457,19 +460,19 @@ def __buildCVECall(
             raise SyntaxError('Invalid date syntax: ' + pubEndDate)
         parameters['pubEndDate'] = date.replace('+', '%2B')
 
-    if sourceIdentifier:
+    if sourceIdentifier is not None:
         parameters['sourceIdentifier'] = sourceIdentifier
 
-    if virtualMatchString:
+    if virtualMatchString is not None:
         virtualMatchString = urllib.parse.quote_plus(
             virtualMatchString, encoding='utf-8')
         parameters['virtualMatchString'] = virtualMatchString
 
-    if versionEnd or versionEndType:
-        if versionEnd and versionEndType and virtualMatchString:
+    if versionEnd is not None or versionEndType is not None:
+        if versionEnd is not None and versionEndType is not None and virtualMatchString is not None:
             if versionEndType not in ['including', 'excluding']:
                 raise SyntaxError(
-                    'versionEnd parameter must be either "included" or "excluded".')
+                    'versionEnd parameter must be either "including" or "excluding".')
             else:
                 parameters['versionEnd'] = str(versionEnd)
                 parameters['versionEndType'] = versionEndType
@@ -477,11 +480,11 @@ def __buildCVECall(
             raise SyntaxError(
                 'If versionEnd is used, all three parameters versionEnd, versionEndType, and virtualMatchString are required.')
 
-    if versionStart or versionStartType:
+    if versionStart is not None or versionStartType is not None:
         if versionStart and versionStartType and virtualMatchString:
             if versionStartType not in ['including', 'excluding']:
                 raise SyntaxError(
-                    'versionStart parameter must be either "included" or "excluded".')
+                    'versionStart parameter must be either "including" or "excluding".')
             else:
                 parameters['versionStart'] = str(versionStart)
                 parameters['versionStartType'] = versionStartType
@@ -489,21 +492,21 @@ def __buildCVECall(
             raise SyntaxError(
                 'If versionStart is used, all three parameters versionStart, versionStartType, and virtualMatchString are required.')
 
-    if limit:
+    if limit is not None:
         if limit > 2000 or limit < 1:
             raise SyntaxError('Limit parameter must be between 1 and 2000')
         parameters['resultsPerPage'] = str(limit)
 
-    if key:
+    if key is not None:
         headers = {'content-type': 'application/json', 'apiKey': key}
     else:
         headers = {'content-type': 'application/json'}
 
-    if delay and key:
+    if delay is not None and key is not None:
         if delay < 0.6:
             raise SyntaxError(
                 'Delay parameter must be greater than 0.6 seconds with an API key. NVD API recommends several seconds.')
-    elif delay and not key:
+    elif delay is not None and key is None:
         raise SyntaxError(
             'Key parameter must be present to define a delay. Requests are delayed 6 seconds without an API key by default.')
 

--- a/nvdlib/get.py
+++ b/nvdlib/get.py
@@ -1,4 +1,4 @@
-from typing import Literal, Dict, Mapping, Union, Optional, LiteralString
+from typing import Literal, Dict, Mapping, Union, Optional, LiteralString, Generator, Any
 
 import requests
 import time
@@ -14,7 +14,7 @@ def __get(
         parameters: Dict[str, Union[str, LiteralString, int]],
         limit: Optional[int] = None,
         delay: Optional[float] = None
-):
+) -> Dict[str, Any]:
     """Calculate required pages for multiple requests, send the GET request with the search criteria, return list of CVEs or CPEs objects."""
 
     # Get the default 2000 items to see the totalResults and determine pages required.
@@ -94,7 +94,8 @@ def __get_with_generator(
         headers: Mapping[str, Union[str, bytes, None]],
         parameters: Dict[str, Union[str, LiteralString, int]],
         limit: Optional[int],
-        delay: float=6):
+        delay: float=6
+) -> Generator[Any, None, None]:
     # Get the default 2000 items to see the totalResults and determine pages required.
     if product == 'cve':
         link = 'https://services.nvd.nist.gov/rest/json/cves/2.0?'

--- a/nvdlib/get.py
+++ b/nvdlib/get.py
@@ -1,3 +1,5 @@
+from typing import Literal, Dict, Mapping, Union, Optional, LiteralString
+
 import requests
 import time
 import logging
@@ -6,7 +8,13 @@ from json.decoder import JSONDecodeError
 
 logger = logging.getLogger(__name__)
 
-def __get(product, headers, parameters, limit, delay):
+def __get(
+        product: Literal["cve", "cpe", "cpeMatch"],
+        headers: Mapping[str, Union[str, bytes, None]],
+        parameters: Dict[str, Union[str, LiteralString, int]],
+        limit: Optional[int] = None,
+        delay: Optional[float] = None
+):
     """Calculate required pages for multiple requests, send the GET request with the search criteria, return list of CVEs or CPEs objects."""
 
     # Get the default 2000 items to see the totalResults and determine pages required.
@@ -35,13 +43,13 @@ def __get(product, headers, parameters, limit, delay):
         logger.error("Invalid search criteria syntax: %s", str(raw))
         logger.error("Attempted search criteria: %s", str(parameters))
 
-    if not delay:
+    if delay is None:
         delay = 6
     time.sleep(delay)
 
     # If a limit is in the search criteria or the total number of results are less than or equal to the default 2000 that were just requested, return and don't request anymore.
     totalResults = raw['totalResults']
-    if limit or totalResults <= 2000:
+    if limit is not None or totalResults <= 2000:
         return raw
 
     # If the results is more than the API limit, figure out how many pages there are and calculate the number of requests.
@@ -81,7 +89,12 @@ def __get(product, headers, parameters, limit, delay):
         return raw
 
 
-def __get_with_generator(product, headers, parameters, limit, delay):
+def __get_with_generator(
+        product: Literal["cve", "cpe", "cpeMatch"],
+        headers: Mapping[str, Union[str, bytes, None]],
+        parameters: Dict[str, Union[str, LiteralString, int]],
+        limit: Optional[int],
+        delay: float=6):
     # Get the default 2000 items to see the totalResults and determine pages required.
     if product == 'cve':
         link = 'https://services.nvd.nist.gov/rest/json/cves/2.0?'
@@ -124,20 +137,15 @@ def __get_with_generator(product, headers, parameters, limit, delay):
         parameters['resultsPerPage'] = '2000'
 
         if startIndex == 0:
-            if limit:
-                logger.debug("Query returned %d total records", totalResults)
-            else:
-                logger.debug("Query returned %d total records", totalResults)
+            logger.debug("Query returned %d total records", totalResults)
 
-        if not limit:
+        if limit is None:
             if startIndex < totalResults:
                 logger.debug("Getting %s batch %d to %d", product, raw["startIndex"], startIndex)
             else:
                 logger.debug("Getting %s batch %d to %d", product, raw["startIndex"], totalResults)
 
-        if limit or startIndex > totalResults:
+        if limit is not None or startIndex > totalResults:
             break
 
-        if not delay:
-            delay = 6
         time.sleep(delay)


### PR DESCRIPTION
So I *think* the `__convert()` function in [classes.py](https://github.com/vehemont/nvdlib/blob/main/nvdlib/classes.py) was missing the case where the `product` parameter is set to "MatchString". I've inferred that this is an intended option for this parameter due to the behaviour of https://github.com/vehemont/nvdlib/blob/main/nvdlib/cpe.py#L339, where this value is passed through. 

If this is not an intended value / not a type which should be returned from this function please let me know and I'm happy to take a look at cpe.py and submit a different PR with a more appropriate value being passed to `__convert()`.

This PR depends on #49 being merged first in order to build on the type hinting implemented in that - apologies for this.