### PR TITLE
Add a proxy option for api calls

### DIFF
--- a/nvdlib/cpe.py
+++ b/nvdlib/cpe.py
@@ -17,7 +17,8 @@ def searchCPE(
         matchCriteriaId: Optional[str] = None,
         limit: Optional[int] = None,
         key: Optional[str] = None,
-        delay: Optional[float] = None
+        delay: Optional[float] = None,
+        proxies: Optional[Dict] = None
 ) -> List[CPE]:
     """Build and send GET request then return list of objects containing a collection of CPEs.
     
@@ -70,10 +71,11 @@ def searchCPE(
         matchCriteriaId,
         limit,
         key,
-        delay)
+        delay
+        )
 
     # Send the GET request for the JSON and convert to dictionary
-    raw = __get('cpe', headers, parameters, limit, delay)
+    raw = __get('cpe', headers, parameters, limit, delay, proxies)
     cpes = []
     # Generates the CVEs into objects for easy referencing and appends them to self.cves
     for eachCPE in raw['products']:
@@ -92,7 +94,8 @@ def searchCPE_V2(
         matchCriteriaId: Optional[str] = None,
         limit: Optional[int] = None,
         key: Optional[str] = None,
-        delay: Optional[float] = None
+        delay: Optional[float] = None,
+        proxies: Optional[Dict] = None
 ) -> Generator[CPE, Any, None]:
     """Build and send GET request then return list of objects containing a collection of CPEs.
     
@@ -148,7 +151,7 @@ def searchCPE_V2(
 
     # Send the GET request. Get a generator object that returns batched
     # responses converted to dictionaries
-    for batch in __get_with_generator('cpe', headers, parameters, limit, delay):
+    for batch in __get_with_generator('cpe', headers, parameters, limit, delay, proxies):
         # Generator object that returns converted CPES
         for eachCPE in batch['products']:
             yield __convert('cpe', eachCPE['cpe'])

--- a/nvdlib/cve.py
+++ b/nvdlib/cve.py
@@ -35,7 +35,8 @@ def searchCVE(
         limit: Optional[int] = None,
         delay: Optional[float] = None,
         key: Optional[str] = None,
-        verbose: Optional[bool] = None
+        verbose: Optional[bool] = None,
+        proxies: Optional[Dict] = None
 ) -> List[CVE]:
     """Build and send GET request then return list of objects containing a collection of CVEs. For more information on the parameters available, please visit https://nvd.nist.gov/developers/vulnerabilities 
 
@@ -155,7 +156,7 @@ def searchCVE(
         key)
 
     # raw is the raw dictionary response.
-    raw = __get('cve', headers, parameters, limit, delay)
+    raw = __get('cve', headers, parameters, limit, delay, proxies)
     cves = []
     # Generates the CVEs into objects for easy access and appends them to self.cves
     for eachCVE in raw['vulnerabilities']:
@@ -192,7 +193,8 @@ def searchCVE_V2(
         limit: Optional[int] = None,
         delay: Optional[float] = None,
         key: Optional[str] = None,
-        verbose: Optional[bool] = None
+        verbose: Optional[bool] = None,
+        proxies: Optional[Dict] = None
 ) -> Generator[List[CVE], Tuple[str, Any], None]:
     """Build and send GET request then return list of objects containing a collection of CVEs. For more information on the parameters available, please visit https://nvd.nist.gov/developers/vulnerabilities 
 
@@ -313,7 +315,7 @@ def searchCVE_V2(
 
     # Send the GET request. Get a generator object that returns batched
     # responses converted to dictionaries
-    for batch in __get_with_generator('cve', headers, parameters, limit, delay):
+    for batch in __get_with_generator('cve', headers, parameters, limit, delay, proxies):
         for eachCVE in batch['vulnerabilities']:
             yield __convert('cve', eachCVE['cve'])
 

--- a/nvdlib/get.py
+++ b/nvdlib/get.py
@@ -13,7 +13,8 @@ def __get(
         headers: Mapping[str, Union[str, bytes, None]],
         parameters: Dict[str, Union[str, LiteralString, int]],
         limit: Optional[int] = None,
-        delay: Optional[float] = None
+        delay: Optional[float] = None,
+        proxies: Optional[Dict] = None
 ) -> Dict[str, Any]:
     """Calculate required pages for multiple requests, send the GET request with the search criteria, return list of CVEs or CPEs objects."""
 
@@ -31,7 +32,7 @@ def __get(
         [k if v is None else f"{k}={v}" for k, v in parameters.items()])
     logger.debug("Filter:\n%s", link + stringParams)
 
-    raw = requests.get(link, params=stringParams, headers=headers, timeout=30)
+    raw = requests.get(link, params=stringParams, headers=headers, timeout=30, proxies=proxies)
     raw.encoding = 'utf-8'
     raw.raise_for_status()
 
@@ -73,7 +74,7 @@ def __get(
             logger.debug("Filter:\n%s", link + stringParams)
             try:
                 getReq = requests.get(
-                    link, params=stringParams, headers=headers, timeout=30)
+                    link, params=stringParams, headers=headers, timeout=30, proxies=proxies)
                 getReq.encoding = 'utf-8'
                 getData = getReq.json()[path]
                 time.sleep(delay)
@@ -111,7 +112,7 @@ def __get_with_generator(
         rate_delay = 1
         while True:
             raw = requests.get(link, params=stringParams,
-                               headers=headers, timeout=30)
+                               headers=headers, timeout=30, proxies=proxies)
             if raw.status_code == 403:
                 logger.error("Request returned a rate limit error. Retrying in %f seconds...", rate_delay)
                 time.sleep(rate_delay)


### PR DESCRIPTION
I had a use case where my project needs to use a proxy for API calls outside the internal network. 

To cover this, I added an optional option to pass the `proxies` object across nvdlib calls down to python requests.

Example:

```python
proxies = {'http': 'http://proxy.local:3128', 'https': 'http://proxy.local:3128'}
cves_list = nvdlib.searchCVE(cpeName = my_cpe , proxies=proxies)
```