### PR TITLE
Bugfix for delay in generator logic

### DIFF
--- a/nvdlib/get.py
+++ b/nvdlib/get.py
@@ -149,4 +149,6 @@ def __get_with_generator(
         if limit is not None or startIndex > totalResults:
             break
 
+        if not isinstance(delay, float):
+            delay = 6
         time.sleep(delay)


### PR DESCRIPTION
The generator logic will no longer fail if the delay parameter is explicitly passed as None